### PR TITLE
Add JSON loader and search example

### DIFF
--- a/game_search.py
+++ b/game_search.py
@@ -1,0 +1,26 @@
+from dotenv import load_dotenv
+import os
+
+from lib.vector_db import VectorStoreManager, CorpusLoaderService
+
+
+def main():
+    load_dotenv()
+    api_key = os.getenv("CHROMA_OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY")
+    manager = VectorStoreManager(api_key, persist_directory="chromadb")
+    loader = CorpusLoaderService(manager)
+
+    store = loader.load_games("udaplay", "games")
+    manager.persist()
+
+    query = "When was Pokémon Gold released?"
+    result = store.query([query], n_results=3)
+
+    for doc, meta in zip(result["documents"][0], result["metadatas"][0]):
+        print(f"{meta['Name']} ({meta['Platform']}) - {meta['YearOfRelease']}")
+        print(doc)
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/loaders.py
+++ b/lib/loaders.py
@@ -1,4 +1,6 @@
 from typing import List
+import os
+import json
 import pdfplumber
 from lib.documents import Corpus, Document
 
@@ -40,4 +42,34 @@ class PDFLoader:
                             content=text
                         )
                     )
+        return corpus
+
+
+class JSONGameLoader:
+    """Load game documents from a directory of JSON files."""
+
+    def __init__(self, directory: str):
+        self.directory = directory
+
+    def load(self) -> Corpus:
+        corpus = Corpus()
+        for file_name in sorted(os.listdir(self.directory)):
+            if not file_name.endswith('.json'):
+                continue
+
+            file_path = os.path.join(self.directory, file_name)
+            with open(file_path, 'r', encoding='utf-8') as f:
+                game = json.load(f)
+
+            content = f"[{game['Platform']}] {game['Name']} ({game['YearOfRelease']}) - {game['Description']}"
+            doc_id = os.path.splitext(file_name)[0]
+
+            corpus.append(
+                Document(
+                    id=doc_id,
+                    content=content,
+                    metadata=game
+                )
+            )
+
         return corpus


### PR DESCRIPTION
## Summary
- add JSONGameLoader to ingest video game JSON data
- extend VectorStoreManager for persistence and add load_games
- provide example script game_search.py to load data and query ChromaDB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0dcf6c10832b9692eeec244584f7