### PR TITLE
Add environment setup sample

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+OPENAI_API_KEY="sk-**********"
+TAVILY_API_KEY="tvly-********"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.env

--- a/config.py
+++ b/config.py
@@ -1,0 +1,6 @@
+from dotenv import load_dotenv
+import os
+
+load_dotenv('config.env')
+assert os.getenv('OPENAI_API_KEY') is not None
+assert os.getenv('TAVILY_API_KEY') is not None


### PR DESCRIPTION
## Summary
- add `.env` example with placeholder API keys
- load env vars in `config.py`
- ignore `config.env` with `.gitignore`

## Testing
- `python - <<'EOF'
try:
    import config
    print('Loaded')
except Exception as e:
    print('Error:', e)
EOF` *(fails: No module named 'dotenv')*
- `pip install python-dotenv` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687d0d68e958832b9e2f0291e9ac07ca