### PR TITLE
Add Streamlit UI and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openai>=1.73.0
 pydantic>=2.11.3
 python-dotenv>=1.1.0
 tavily-python>=0.5.4
+streamlit>=1.34.0

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,39 @@
+import os
+from dotenv import load_dotenv
+import streamlit as st
+from lib.game_agent import GameAgent
+
+
+def check_env() -> list[str]:
+    """Return list of missing environment keys required for the agent."""
+    required = ["OPENAI_API_KEY", "TAVILY_API_KEY", "CHROMA_OPENAI_API_KEY"]
+    return [k for k in required if not os.getenv(k)]
+
+
+def main():
+    load_dotenv("config.env")
+    missing = check_env()
+    if missing:
+        st.error(
+            "Missing the following API keys: "
+            + ", ".join(missing)
+            + ". Please update config.env and restart."
+        )
+        st.stop()
+
+    st.title("UdaPlay Game Agent")
+    query = st.text_input("Ask a question about video games")
+    if st.button("Ask") and query:
+        agent = GameAgent()
+        with st.spinner("Thinking..."):
+            run = agent.invoke(query)
+        final = run.get_final_state()
+        answer = final.get("answer") if final else None
+        if answer:
+            st.write(answer)
+        else:
+            st.write("No answer available.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,14 @@
+import importlib
+import sys
+
+
+def test_check_env_missing(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.delenv("CHROMA_OPENAI_API_KEY", raising=False)
+    app = importlib.import_module("streamlit_app")
+    importlib.reload(app)
+    missing = app.check_env()
+    assert "OPENAI_API_KEY" in missing
+    assert "TAVILY_API_KEY" in missing
+    assert "CHROMA_OPENAI_API_KEY" in missing

--- a/tests/test_game_agent.py
+++ b/tests/test_game_agent.py
@@ -1,0 +1,33 @@
+import importlib
+import sys
+import types
+
+
+def test_game_agent_runs(monkeypatch):
+    dummy = types.SimpleNamespace()
+
+    class DummyCompletion:
+        @staticmethod
+        def create(**kwargs):
+            class Response:
+                choices = [
+                    types.SimpleNamespace(
+                        message=types.SimpleNamespace(content="answer")
+                    )
+                ]
+                usage = None
+
+            return Response()
+
+    dummy.OpenAI = lambda api_key=None: types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=DummyCompletion)
+    )
+    monkeypatch.setitem(sys.modules, "openai", dummy)
+
+    ga = importlib.import_module("lib.game_agent")
+    importlib.reload(ga)
+
+    agent = ga.GameAgent()
+    run = agent.invoke("Who made Mario?")
+    final = run.get_final_state()
+    assert final.get("answer") == "answer"


### PR DESCRIPTION
## Summary
- add a simple Streamlit interface for the game agent
- verify missing API keys using `check_env`
- provide minimal unit tests for env checking and agent execution
- include Streamlit in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687d0fccb48c832ba91ad26ecaf694b3