### PR TITLE
Add setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,12 @@ project/
 
 ## Getting Started
 
-1. Create and activate a virtual environment
-2. Install required dependencies
-3. Set up your `.env` file with necessary API keys
-4. Follow the notebooks in order:
+1. Run the setup script to create a virtual environment and install all
+   dependencies:
+   - On Linux/macOS: `./setup_linux.sh`
+   - On Windows: `setup_windows.bat`
+2. Set up your `.env` file with necessary API keys
+3. Follow the notebooks in order:
    - Complete Part 1 to set up your vector database
    - Complete Part 2 to implement the AI agent
 

--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Setup Python virtual environment for UdaPlay project on Linux/Mac
+set -e
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+echo
+echo "Setup complete. Activate the environment with:"
+echo "  source .venv/bin/activate"

--- a/setup_windows.bat
+++ b/setup_windows.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Setup Python virtual environment for UdaPlay project on Windows
+python -m venv .venv
+if %ERRORLEVEL% neq 0 (
+    echo Failed to create virtual environment.
+    exit /b 1
+)
+call .venv\Scripts\activate
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+if %ERRORLEVEL% neq 0 (
+    echo Failed to install dependencies.
+    exit /b 1
+)
+echo.
+echo Setup complete. Activate the environment with:
+echo   call .venv\Scripts\activate


### PR DESCRIPTION
## Summary
- add setup scripts for Linux and Windows to create virtualenv and install requirements
- update README with instructions on running the new scripts

## Testing
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lib')*

------
https://chatgpt.com/codex/tasks/task_e_687d1169c640832b870ea7feac30381a