### PR TITLE
Add local ChromaDB install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ TAVILY_API_KEY="YOUR_KEY"
 - Tavily
 - dotenv
 
+### Local ChromaDB Setup
+Two helper scripts are provided to install and run ChromaDB locally:
+
+- `scripts/install_chromadb_linux.sh` – for Linux environments
+- `scripts/install_chromadb_windows.ps1` – for Windows environments
+
+Running either script will install the `chromadb` Python package and launch a local server that persists data in the `chromadb` directory. Execute the script from the project root.
+
 ### Directory Structure
 ```
 project/

--- a/scripts/install_chromadb_linux.sh
+++ b/scripts/install_chromadb_linux.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# install_chromadb_linux.sh - Install and start ChromaDB locally on Linux.
+set -e
+
+# Install ChromaDB using pip
+python3 -m pip install --upgrade chromadb
+
+# Start the ChromaDB server with persistence in ./chromadb
+exec chroma run --path ./chromadb

--- a/scripts/install_chromadb_windows.ps1
+++ b/scripts/install_chromadb_windows.ps1
@@ -1,0 +1,7 @@
+# install_chromadb_windows.ps1 - Install and start ChromaDB locally on Windows.
+
+# Install ChromaDB using pip
+python -m pip install --upgrade chromadb
+
+# Start the ChromaDB server with persistence in ./chromadb
+chroma run --path ./chromadb


### PR DESCRIPTION
## Summary
- document local ChromaDB installation in README
- add Linux helper script to install & start ChromaDB
- add Windows helper script to install & start ChromaDB

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687d11cc34b8832b8c2a151dfef031ca