### PR TITLE
Convert notebooks, fix env loading

### DIFF
--- a/Udaplay_01_starter_project.py
+++ b/Udaplay_01_starter_project.py
@@ -1,0 +1,72 @@
+# Only needed for Udacity workspace
+# !pip install chromadb
+import importlib.util
+import sys
+
+# Check if 'pysqlite3' is available before importing
+if importlib.util.find_spec("pysqlite3") is not None:
+    import pysqlite3
+    sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
+
+import os
+import json
+import chromadb
+from chromadb.utils import embedding_functions
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+
+chroma_client = chromadb.PersistentClient(path="chromadb")
+
+embedding_fn = embedding_functions.OpenAIEmbeddingFunction(api_key=os.getenv("CHROMA_OPENAI_API_KEY"))
+
+collection = chroma_client.get_or_create_collection(
+    name="udaplay",
+    embedding_function=embedding_fn
+)
+
+import os
+import json
+from tqdm import tqdm  # Importa o tqdm para barra de progresso
+import chromadb
+from chromadb.utils import embedding_functions
+
+# Diretório de dados
+data_dir = "games"
+
+# Verifica se diretório existe
+if not os.path.exists(data_dir):
+    raise FileNotFoundError(f"Diretório '{data_dir}' não encontrado.")
+
+# Inicializa o cliente e coleção do Chroma
+embedding_fn = embedding_functions.OpenAIEmbeddingFunction(
+    api_key=os.getenv("OPENAI_API_KEY"),  # ou use diretamente a chave como string
+    model_name="text-embedding-ada-002"
+)
+client = chromadb.Client()
+collection = client.get_or_create_collection(name="games", embedding_function=embedding_fn)
+
+# Lista apenas arquivos JSON
+file_list = [f for f in sorted(os.listdir(data_dir)) if f.endswith(".json")]
+
+# Itera com tqdm para mostrar progresso
+for file_name in tqdm(file_list, desc="Processando arquivos JSON"):
+    try:
+        file_path = os.path.join(data_dir, file_name)
+        with open(file_path, "r", encoding="utf-8") as f:
+            game = json.load(f)
+
+        content = f"[{game['Platform']}] {game['Name']} ({game['YearOfRelease']}) - {game['Description']}"
+        doc_id = os.path.splitext(file_name)[0]
+
+        collection.add(
+            ids=[doc_id],
+            documents=[content],
+            metadatas=[game]
+        )
+    except Exception as e:
+        print(f"❌ Erro ao processar {file_name}: {e}")
+
+

--- a/Udaplay_02_starter_project.py
+++ b/Udaplay_02_starter_project.py
@@ -1,0 +1,88 @@
+# Only needed for Udacity workspace
+
+import importlib.util
+import sys
+
+# Check if 'pysqlite3' is available before importing
+if importlib.util.find_spec("pysqlite3") is not None:
+    import pysqlite3
+    sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
+
+import os
+from dotenv import load_dotenv
+from lib.game_tools import retrieve_game, evaluate_retrieval, game_web_search
+from lib.game_agent import GameAgent
+
+load_dotenv()
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+TAVILY_API_KEY = os.getenv("TAVILY_API_KEY")
+
+
+def retrieve_game(query: str) -> List[Dict]:
+    """Search game information from the local vector database."""
+    client = chromadb.PersistentClient(path="chromadb")
+    collection = client.get_collection("udaplay")
+    result = collection.query(query_texts=[query], n_results=3, include=["documents", "metadatas"])
+    documents = result.get("documents", [[]])[0]
+    metadatas = result.get("metadatas", [[]])[0]
+    games = []
+    for doc, meta in zip(documents, metadatas):
+        game = {
+            "Name": meta.get("Name"),
+            "Platform": meta.get("Platform"),
+            "YearOfRelease": meta.get("YearOfRelease"),
+            "Description": meta.get("Description"),
+        }
+        games.append(game)
+    return games
+
+class EvaluationReport(BaseModel):
+    useful: bool
+
+@tool(name="evaluate_retrieval", description="Based on the user's question and on the list of retrieved documents, analyze if they can answer the question")
+def evaluate_retrieval(question: str, retrieved_docs: List[str]) -> EvaluationReport:
+    """Assess if retrieved docs are enough to answer the question."""
+    from lib.llm import LLM
+    from lib.parsers import PydanticOutputParser
+
+    llm = LLM(model="gpt-4o-mini")
+    docs = "\n".join(retrieved_docs)
+    prompt = (
+        "Your task is to evaluate if the documents are enough to respond the query. "
+        "Give a detailed explanation, so it's possible to take an action to accept it or not.\n"
+        f"# Question:\n{question}\n# Documents:\n{docs}\nRespond with JSON." )
+
+    ai_message = llm.invoke(prompt)
+    parser = PydanticOutputParser(model_class=EvaluationReport)
+    try:
+        report = parser.parse(ai_message)
+    except Exception:
+        # fallback simple parse
+        content = ai_message.content or ""
+        useful = "yes" in content.lower()
+        report = EvaluationReport(useful=useful, description=content)
+    return report
+
+@tool(name="game_web_search", description="Semantic search: Finds most results in the vector DB")
+def game_web_search(question: str) -> List[Dict]:
+    """Perform a Tavily web search for additional information."""
+    import requests
+
+    if not api_key:
+        raise ValueError("Missing TAVILY_API_KEY")
+    url = "https://api.tavily.com/search"
+    payload = {"api_key": api_key, "query": question, "search_depth": "basic"}
+    resp = requests.post(url, json=payload, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("results", [])
+
+
+agent = GameAgent()
+
+agent.invoke("When Pokémon Gold and Silver was released?")
+agent.invoke("Which one was the first 3D platformer Mario game?")
+agent.invoke("Was Mortal Kombat X realeased for Playstation 5?")
+
+# Agent already uses ShortTermMemory for session history
+

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 from dotenv import load_dotenv
 import os
 
-load_dotenv('config.env')
+if not load_dotenv():
+    load_dotenv('config.env')
 assert os.getenv('OPENAI_API_KEY') is not None
 assert os.getenv('TAVILY_API_KEY') is not None

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -48,13 +48,14 @@ def check_env() -> list[str]:
 
 
 def main():
-    load_dotenv("config.env")
+    if not load_dotenv():
+        load_dotenv("config.env")
     missing = check_env()
     if missing:
         st.error(
             "Missing the following API keys: "
             + ", ".join(missing)
-            + ". Please update config.env and restart."
+            + ". Please update your .env file and restart."
         )
         st.stop()
 


### PR DESCRIPTION
## Summary
- add Python scripts converted from starter notebooks
- load environment variables from `.env` or fallback to `config.env`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2c8cf918832ba4d9d1d85a6f49b9