### PR TITLE
Add Docker Compose support for ChromaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,23 +80,24 @@ Create a `.env` file with the following API keys:
 ```
 OPENAI_API_KEY="YOUR_KEY"
 TAVILY_API_KEY="YOUR_KEY"
+CHROMA_URL="http://localhost:8000"
 ```
-ChromaDB now relies on OpenAI embeddings, so `OPENAI_API_KEY` must be configured.
-
 ### Project Dependencies
+ChromaDB now relies on OpenAI embeddings, so `OPENAI_API_KEY` must be configured.
 - Python 3.11+
 - ChromaDB
 - OpenAI
 - Tavily
 - dotenv
 
-### Local ChromaDB Setup
-Two helper scripts are provided to install and run ChromaDB locally:
+### ChromaDB Setup with Docker Compose
+A `docker-compose.yml` file is provided to run ChromaDB. Start it with:
 
-- `scripts/install_chromadb_linux.sh` – for Linux environments
-- `scripts/install_chromadb_windows.ps1` – for Windows environments
+```bash
+docker compose up -d chromadb
+```
 
-Running either script will install the `chromadb` Python package and launch a local server that persists data in the `chromadb` directory. Execute the script from the project root.
+The service listens on `http://localhost:8000` and stores data in the `chromadb` directory. Set `CHROMA_URL=http://localhost:8000` before running the project.
 
 ### Directory Structure
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  chromadb:
+    image: ghcr.io/chroma-core/chroma:0.4.13
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./chromadb:/chroma/chroma
+    environment:
+      IS_PERSISTENT: "TRUE"


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` for running ChromaDB
- document Docker setup and CHROMA_URL env var
- connect to remote ChromaDB if `CHROMA_URL` is set
- update starter script to use `CHROMA_URL`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d48b9ee7c832ba67b87d1989030a6