### PR TITLE
Add inline video playback in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ In this project, you will build an AI Research Agent called UdaPlay designed to 
 
 ## Project Overview
 UdaPlay is an AI-powered research agent for the video game industry. This project is divided into two main parts that will help you build a sophisticated AI agent capable of answering questions about video games using both local knowledge and web searches.
-A short demonstration video (`udaplay.mp4`) is included in this repository.
+A short demonstration video (`udaplay.mp4`) is included in this repository and can be played directly below.
+
+<video src="udaplay.mp4" controls width="600" title="UdaPlay demo"></video>
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- embed the demo video directly in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*
- `pip install sentence_transformers` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687daa0abdec832bb9d2e03a736bdea5